### PR TITLE
strip ext off of image link

### DIFF
--- a/Weathermap.inc.php
+++ b/Weathermap.inc.php
@@ -24,7 +24,7 @@ if(! is_writable('plugins/Weathermap/configs')) {
     <ul class="list-inline">');
   foreach($images as $image) {
     $overlib = pathinfo($image);
-    $overlib = $overlib['dirname'] . '/' . $overlib['basename'] . '.html';
+    $overlib = $overlib['dirname'] . '/' . substr($overlib['basename'], 0, strrpos($overlib['basename'], '.')) . '.html';
     echo('<li><a href="' . $overlib . '"><img class="img-responsive" src="' . $image . '"/></a></li>');
   }
   echo('</ul>


### PR DESCRIPTION
Fix for #11 

altering <code>$overlib['basename']</code> to strip the extension off.

It works, but I don't know if that is the way you want it fixed.