### PR TITLE
Allow user to configure which ports are shown in data-picker on load.

### DIFF
--- a/data-pick.php
+++ b/data-pick.php
@@ -17,6 +17,10 @@ $config_file_paths = array (
 	'../../../config.php',
 );
 
+$weathermap_config = array (
+	'sort_if_by' => 'ifAlias',
+);
+
 $valid_sort_if_by = array (
 	'ifAlias',
 	'ifDescr',
@@ -43,6 +47,8 @@ if (file_exists ($config_file_path)) {
 	require ($config_file_path);
 	$librenms_base = $config['install_dir'];
 	include_once ("$librenms_base/includes/defaults.inc.php");
+	/* Load Weathermap config defaults, see file for description. */
+	include_once ("defaults.inc.php");
 	require ($config_file_path);
 
 	// FIXME: Why is this neccessary?!
@@ -58,6 +64,10 @@ if (file_exists ($config_file_path)) {
 
 	chdir('plugins/Weathermap');
 	$librenms_found = TRUE;
+
+	/* Validate configuration */
+	if (in_array ($config['plugins']['Weathermap']['sort_if_by'], $valid_sort_if_by))
+		$weathermap_config['sort_if_by'] = $config['plugins']['Weathermap']['sort_if_by'];
 }
 else {
 	$librenms_found = FALSE;
@@ -325,8 +335,12 @@ if(sizeof($hosts) > 0) {
 
 	print '</form><div class="listcontainer"><ul id="dslist">';
 
+	/*
+	 * Query interfaces...
+	 */
 	$query = "SELECT devices.device_id,hostname,ports.port_id,ports.ifAlias,ports.ifIndex,ports.ifDescr,ports.deleted FROM devices LEFT JOIN ports ON devices.device_id=ports.device_id WHERE ports.disabled=0";
 
+	/* ...of specific host/device? */
 	if($host_id > 0) {
 		$query .= " AND devices.device_id='$host_id'";
 	}
@@ -337,6 +351,9 @@ if(sizeof($hosts) > 0) {
 	} else {
 		$query .= " ORDER BY hostname,ports.ifAlias";
 	}
+
+	/* ...in specific order? */
+	$query .= " ORDER BY hostname,ports." . $weathermap_config['sort_if_by'];
 	$result = mysqli_query($link,$query);
 
 	// print $SQL_picklist;

--- a/defaults.inc.php
+++ b/defaults.inc.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * By default the data-picker shows interfaces ORDERed by their ifAlias.
+ * This might be confusing at times. Now it's possible to configure the
+ * data picker to order the interface list by one of
+ *
+ *   'ifAlias', 'ifDescr', 'ifIndex', 'ifName'
+ *
+ * by setting
+ *
+ *  $config['plugins']['Weathermap']['sort_if_by']
+ *
+ * in the libreNMS config.php file to the according value.
+ */
+$config['plugins']['Weathermap']['sort_if_by'] = 'ifAlias';
+
+?>

--- a/defaults.inc.php
+++ b/defaults.inc.php
@@ -15,4 +15,16 @@
  */
 $config['plugins']['Weathermap']['sort_if_by'] = 'ifAlias';
 
+
+/* By default all interfaces of all devices are loaded and listed when
+ * opening the data-picker. In large setups this will cause high loading
+ * times every time the data-picker is loaded. With the following option
+ * this behvaiour can be changed, valid values are:
+ *
+ *  'all', 'any', '-1'	Show all ports (default)
+ *  'none', '0'		Don't load any ports.
+ *   <integer> >= 0	Show port of libreNMS $device_id
+ *
+ */
+$config['plugins']['Weathermap']['show_interfaces'] = 'all';
 ?>


### PR DESCRIPTION
By default all interfaces of all devices are loaded and listed when
opening the data-picker. In large setups this will cause high loading
times every time the data-picker is loaded. With the following option
this behvaiour can be changed, valid values are:

   'all', 'any', '-1'  Show all ports (default)
   'none', '0'         Don't load any ports.
    <integer> >= 0     Show port of libreNMS $device_id

$config['plugins']['Weathermap']['show_interfaces'] = 'all';
