### PR TITLE
Try to show only interfaces from links source node in data-picker

### DIFF
--- a/data-pick.php
+++ b/data-pick.php
@@ -309,11 +309,21 @@ if(isset($_REQUEST['command']) && $_REQUEST["command"]=='link_step1')
 	if(isset($_REQUEST['aggregate'])) $aggregate = ( $_REQUEST['aggregate']==0 ? false : true);
 	if(isset($_REQUEST['overlib'])) $overlib= ( $_REQUEST['overlib']==0 ? false : true);
 	
-	
-	if(isset($_REQUEST['host_id']))
+	/* Explicit device_id given? */
+	if (isset ($_REQUEST['host_id']) and !empty ($_REQUEST['host_id']))
 	{
-		$host_id = intval($_REQUEST['host_id']);
+		$host_id = intval ($_REQUEST['host_id']);
 		//if($host_id>=0) $SQL_picklist .= " and data_local.host_id=$host_id ";
+	}
+
+	/* If the editor gave us the links source node name, try to find the device_id
+	 * so we can present the user with the interfaces of this particular device. */
+	if (isset ($_REQUEST['node1']) and !empty ($_REQUEST['node1']))
+	{
+		$node1 = $_REQUEST['node1'];
+		$node1_id = dbFetchCell ("SELECT device_id FROM devices where hostname like ?", array ("%$node1%"));
+		if ($node1_id)
+			$host_id = $node1_id;
 	}
 	
 	//$SQL_picklist .= " order by name_cache;";

--- a/editor-resources/editor.js
+++ b/editor-resources/editor.js
@@ -240,6 +240,8 @@ function do_submit()
 
 function librenmspicker()
     {
+    node1 = document.getElementById('link_nodename1a').textContent;
+
     // make sure it isn't already opened
     if (!newWindow || newWindow.closed)
         {
@@ -253,7 +255,7 @@ function librenmspicker()
         }
 
     // newWindow.location = "data-pick.php?command=link_step1";
-    newWindow.location = "data-pick.php?command=link_step1";
+    newWindow.location = "data-pick.php?command=link_step1&node1=" + node1;
     }
 
 


### PR DESCRIPTION
The Weathermap editor knows about a source and destinaton node name of links.
Assuming that the node names correspond with device names within LibreNMS, we
can provide the source node name to the data-picker for RRD selection and use
the name to lookup a device-id and only show interfaces of this node if the
device exists. This obviously saves some clicks to be made by the users.