### PR TITLE
Adding namespace LibreNMS\Plugins;

### DIFF
--- a/Weathermap.php
+++ b/Weathermap.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LibreNMS\Plugins;
+
 include_once 'lib/editor.inc.php';
 
 class Weathermap {


### PR DESCRIPTION
Hello,

Seems that the namespace is now mandatory. Get a Laravel "Whoops" without it. 

PipoCanaja