### PR TITLE
Fix rrdcached support

### DIFF
--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -249,6 +249,12 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$args[] = $start;
 		$args[] = "--end";
 		$args[] = $end;
+		
+		// rrdcached Support: Use daemon
+		if ($map->daemon){
+			$args[] = "--daemon";
+			$args[] = $map->daemon_args;
+		}
 
 		# assemble an appropriate RRDtool command line, skipping any '-' DS names.
 		# $command = $map->rrdtool . " graph /dev/null -f ''  --start $start --end $end ";
@@ -274,7 +280,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 			$args[] = "VDEF:agg_out=out,$aggregatefn";
 			$args[] = "PRINT:agg_out:'OUT %lf'";
 		}
-
+		
 		$command = $map->rrdtool;
 		foreach ($args as $arg)
 		{
@@ -374,6 +380,12 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
 		$args[] = $start;
 		$args[] = "--end";
 		$args[] = $end;
+		
+		// rrdcached Support: Use daemon
+		if ($map->daemon){
+			$args[] = "--daemon";
+			$args[] = $map->daemon_args;
+		}
 
 		$command = $map->rrdtool;
 		foreach ($args as $arg)


### PR DESCRIPTION
rrdcached support was broken in 8955b99ac7d31581e2fb0e7d037311a9fb3389a8 removing the addition of the --daemon option to the rrdtool command. This simply adds the daemon argument in lib/datasources/WeatherMapDataSource_rrd.php, if set in weathermap.php, allowing this plugin to correctly function with rrdcached.