### PR TITLE
Minimal set of patches to get Weathermap to work with php 8.0

### DIFF
--- a/lib/Weathermap.class.php
+++ b/lib/Weathermap.class.php
@@ -960,8 +960,8 @@ class WeatherMap extends WeatherMapBase
                                 if ($multiply != 1) {
                                     wm_debug("Pre-multiply: $in $out\n");
 
-                                    $in = $multiply * $in;
-                                    $out = $multiply * $out;
+                                    $in = (int) $multiply * $in;
+                                    $out = (int) $multiply * $out;
 
                                     wm_debug("Post-multiply: $in $out\n");
                                 }
@@ -3491,6 +3491,7 @@ class WeatherMap extends WeatherMapBase
                         $result = imagegif($image, $filename);
                     } elseif (function_exists('imagepng') && preg_match("/\.png/i", $filename)) {
                         wm_debug("Writing PNG file to $filename\n");
+                        print("Writing PNG file to $filename\n");
                         $result = imagepng($image, $filename);
                     } else {
                         wm_warn("Failed to write map image. No function existed for the image format you requested. [WMWARN12]\n");

--- a/lib/editor.inc.php
+++ b/lib/editor.inc.php
@@ -117,6 +117,9 @@ function list_weathermaps($mapdir)
     global $WEATHERMAP_VERSION, $config_loaded, $cacti_found, $ignore_cacti,$configerror, $action;
 
     $titles = array();
+    $files = array();
+    $pages = array();
+    $notes = array();
 
     $errorstring="";
 


### PR DESCRIPTION
When trying to use the Weathermap plugin with a LibreNMS (FreeBSD package librenms-22.2.1,1, which uses php 8.0 for its dependencies) I had to make the fixes as made in this pull request.