### PR TITLE
Adding a fix to allow IPv6 addresses by replacing ":" by underscore

### DIFF
--- a/data-pick.php
+++ b/data-pick.php
@@ -194,6 +194,9 @@ if(isset($_REQUEST['command']) && $_REQUEST["command"]=='link_step1')
 		var newlocation;
 		var fullpath;
 
+		// Replace semi-colons by underscores to permit IPv6 addresses
+		var name = name.replace(/:/g,'_');
+
 		var rra_path = <?php echo js_escape('./'); ?>+name+'/port-id';
 
 		if (typeof window.opener == "object") {


### PR DESCRIPTION
During the conception of our weathermap @ Telerys Communication, we noticed that devices's RRD with IPv6 addresses are stored with this format: XXXX_XXXX_XXXX_XXXX.
PHP Weathermap use ":" instead of "_".

This fix replaces ":" by "_" to allow the usage of IPv6 devices with PHP Weathermap.