### PR TITLE
Update data-pick.php

### DIFF
--- a/data-pick.php
+++ b/data-pick.php
@@ -326,7 +326,7 @@ if($hosts->isNotEmpty()) {
 	}
 
 	$i=0;
-    if ($devices->isNotEmpty()) {
+    if ($devices !== null && $devices->isNotEmpty()) {
         foreach ($devices as $device) {
             if (!is_null($device->ports)) {
                 foreach ($device->ports as $port) {


### PR DESCRIPTION
A quick fix for PHP 8.X for this error. 
production.ERROR: Call to a member function isNotEmpty() on null {"userId":1,"exception":"[object] (Error(code: 0): Call to a member function isNotEmpty() on null at /opt/librenms/html/plugins/Weathermap/data-pick.php:329)