### PR TITLE
Fix deprecated use of curly brackets for string offsets.

### DIFF
--- a/check.php
+++ b/check.php
@@ -258,7 +258,7 @@
       $val = trim($val);
       if($val != '')
       {
-      $last = strtolower($val{strlen($val)-1});
+      $last = strtolower($val[strlen($val)-1]);
       switch($last) {
           // The 'G' modifier is available since PHP 5.1.0
           case 'g':


### PR DESCRIPTION
Minor change, fixing:
`PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /opt/librenms/html/plugins/Weathermap/check.php on line 261`

Tested with PHP 8.1.14 and PHP 8.1.2